### PR TITLE
Arreglado cierre drawer activiy y error al listar usuarios del sistema

### DIFF
--- a/app/src/main/java/com/example/teleappsistencia/MainActivity.java
+++ b/app/src/main/java/com/example/teleappsistencia/MainActivity.java
@@ -721,11 +721,11 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                     transaction.addToBackStack(null);
                     transaction.commit();
                 }
-                /*if (headerList.get(groupPosition).isGroup()) {
-                    if (!headerList.get(groupPosition).hasChildren()) {
-                        // En este caso no hay nada que hacer al pulsar en una opción principal.
-                    }
-                }*/
+                // Cerramos el drawer al pulsar una opción sin hijos si no es  un grupo y no tiene hijos
+                if (!headerList.get(groupPosition).isGroup() && !headerList.get(groupPosition).hasChildren()) {
+                    DrawerLayout drawer = findViewById(R.id.drawer_layout);
+                    drawer.closeDrawer(GravityCompat.START);
+                }
                 /* Estas dos lineas de código hacen que siempre que se pulse una
                 opción principal del menú cargue un fragment en blanco.
 

--- a/app/src/main/java/com/example/teleappsistencia/ui/fragments/usuarios_sistema/UsuariosSistemaFragment.java
+++ b/app/src/main/java/com/example/teleappsistencia/ui/fragments/usuarios_sistema/UsuariosSistemaFragment.java
@@ -139,8 +139,7 @@ public class UsuariosSistemaFragment extends Fragment implements OpcionesListaFr
 
             @Override
             public void onFailure(Call<List<Usuario>> call, Throwable t) {
-                t.printStackTrace();
-
+                Toast.makeText(getContext(), Constantes.TOAST_USUARIOSISTEMA_ERROR, Toast.LENGTH_SHORT).show();
                 // Detener el shimmer
                 detenerShimmer();
             }


### PR DESCRIPTION
El error de que no se cerraba el drawer al pulsar los usuarios del sistema es porque faltaban unas líneas.

El error de que no se muestre ningún usuario del sistema es un error de conexión con el servidor.
He añadido un Toast para que el usuario sea consciente de esto.